### PR TITLE
⚡️ : 칸반보드 y스크롤 제거, 양쪽너비 제한

### DIFF
--- a/src/main/webapp/WEB-INF/views/kanban/kanban_board.jsp
+++ b/src/main/webapp/WEB-INF/views/kanban/kanban_board.jsp
@@ -82,24 +82,28 @@ form {
 	<header>
 		<jsp:include page="/WEB-INF/views/common/header.jsp"></jsp:include>
 	</header>
-	<div class="row">
-			<div class="col-3 column-header text-center fs-3">조회</div>
-			<div class="col-3 column-header text-center fs-3 text-warning text-opacity-75">즐겨찾기</div>
-			<div class="col-3 column-header text-center fs-3 text-danger">매수</div>
-			<div class="col-3 column-header text-center fs-3 text-primary">매도</div>
+	<div class="row_container d-flex justify-content-center mt-5">
+		<div class="row" style="width:88%">
+				<div class="col-3 column-header text-center fs-3">조회</div>
+				<div class="col-3 column-header text-center fs-3 text-warning text-opacity-75">즐겨찾기</div>
+				<div class="col-3 column-header text-center fs-3 text-danger">매수</div>
+				<div class="col-3 column-header text-center fs-3 text-primary">매도</div>
+		</div>
 	</div>
-	<div class="board">
-		<div class="column sortable">
-			<div class="sortable" id="todo" connectWith=".sortable"></div>
-		</div>
-		<div class="column sortable">
-			<div class="sortable" id="inProgress" connectWith=".sortable"></div>
-		</div>
-		<div class="column sortable">
-			<div class="sortable" id="done" connectWith=".sortable"></div>
-		</div>
-		<div class="column sortable">
-			<div class="sortable" id="newColumn" connectWith=".sortable"></div>
+	<div class="board_container d-flex justify-content-center">
+		<div class="board" style="width:88%">
+			<div class="column sortable" style="overflow-y: hidden">
+				<div class="sortable" id="todo" connectWith=".sortable"></div>
+			</div>
+			<div class="column sortable" style="overflow-y: hidden">
+				<div class="sortable" id="inProgress" connectWith=".sortable"></div>
+			</div>
+			<div class="column sortable" style="overflow-y: hidden">
+				<div class="sortable" id="done" connectWith=".sortable"></div>
+			</div>
+			<div class="column sortable" style="overflow-y: hidden">
+				<div class="sortable" id="newColumn" connectWith=".sortable"></div>
+			</div>
 		</div>
 	</div>
 	<!-- 

--- a/src/main/webapp/resources/css/header.css
+++ b/src/main/webapp/resources/css/header.css
@@ -7,7 +7,7 @@ header {
     height: 100vh;*/
     margin: auto;
     padding-top: 50px;
-    padding-bottom: 50px;
+    padding-bottom: 25px;
 }
 .top {
     width: 100%;


### PR DESCRIPTION
- width 85%, 가운데 정렬
- 각 보드 내 y스크롤 제거